### PR TITLE
oauth fix

### DIFF
--- a/app/services/return-url.js
+++ b/app/services/return-url.js
@@ -55,7 +55,7 @@ define(['app', 'lodash'], function (app, _) { 'use strict';
                 window.location.href = url;
             }
             else {
-                $location.path(url);
+                $location.location(url);
             }                  
         }
 


### PR DESCRIPTION
- return url not preserving query string on navigate