### PR TITLE
DEV-666 Adds drupal subdomain to trusted hosts

### DIFF
--- a/app/authorize.html
+++ b/app/authorize.html
@@ -31,6 +31,7 @@ function setCookie(cname, cvalue, exdays)
     document.cookie =  parts.join("; ");
 }
 var trustedHosts = [
+    [/^drupal\.www\.infra\.cbd\.int$/i, /.*\.drupal\.www\.infra\.cbd\.int$/i],
     [/^staging\.cbd\.int$/i, /.*\.staging\.cbd\.int$/i],
     [/^cbddev\.xyz$/i, /.*\.cbddev\.xyz$/i],
     [/^cbd\.int$/i, /.*\.cbd\.int$/i]


### PR DESCRIPTION
Adds drupal subdomain regex to the list of trusted hosts, allowing authentication from the production drupal environment.

Relates to DEV-666